### PR TITLE
QRコード生成するためにサイズに指定用のスライダーを導入

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
         <el-input class="form__url" type="url" placeholder="qr-generate.whyk.dev" v-model="url">
           <template slot="prepend">http(s)://</template>
         </el-input>
-        <el-input-number class="form__size" v-model="size" :min="50" :max="1000" :step="5"/>
+        <el-slider class="form__size" v-model="size" :min="50" :max="1000" :step="5" show-input/>
         <el-select class="form__extension" v-model="extension" clearable placeholder="jpg">
           <el-option v-for="item in options" :key="item.value" :label="item.label" :value="item.value" />
         </el-select>


### PR DESCRIPTION
### 目的
QRコード生成するとき`+/-` を手動に押すや、（`50~1000` までの）値を書き込むより、スライダーもさえあればもっとナチュラルかもしれないと感じて導入することにしました！

### Before
<img width="500" alt="image" src="https://user-images.githubusercontent.com/6195689/96853321-2a762300-1495-11eb-9b97-ac1fe1b520fd.png">

### After
<img width="500" alt="image" src="https://user-images.githubusercontent.com/6195689/96853288-21855180-1495-11eb-85cc-e5d85bf9cdb6.png">

小さな変更ですがご検討ほどよろしくお願い致します＾＾
