### PR TITLE
fix: QR API クエリのエスケープと color 入力のコンソール警告解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 デザインができるQRコード生成ツールがほしかった。  
 現状はデザインできないけど、将来的にできるといい。
 
-[SvelteKit](https://kit.svelte.dev)と[Flowbite Svelte](https://flowbite-svelte.com)で実装。  
+[SvelteKit](https://svelte.dev/docs/kit)と[Tailwind CSS](https://tailwindcss.com)で実装。  
 QRコード生成APIは[QR server](https://github.com/windchime-yk/qr-server)を利用している。

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,19 +8,25 @@
     { value: 'svg', name: 'svg' }
   ];
 
+  const DEFAULT_QR_COLOR = '#000000';
+  const DEFAULT_BG_COLOR = '#ffffff';
+
   let url = $state('');
   let imageSize = $state(100);
   let selectedExtention = $state('svg');
-  let qrcolor = $state('#000000');
-  let bgcolor = $state('#ffffff');
+  let qrcolor = $state(DEFAULT_QR_COLOR);
+  let bgcolor = $state(DEFAULT_BG_COLOR);
 
+  // URLSearchParams に任せて各値をエスケープする。素の文字列連結だと
+  // 入力 URL に含まれる & や ? がクエリの区切りとして解釈されてしまう
   const qrImageUrl = $derived(
-    `https://qr.whyk.dev/api?url=${
-      url || 'https://example.com'
-    }&width=${imageSize}&type=${selectedExtention}&qrcolor=${qrcolor.replace(
-      '#',
-      ''
-    )}&bgcolor=${bgcolor.replace('#', '')}`
+    `https://qr.whyk.dev/api?${new URLSearchParams({
+      url: url || 'https://example.com',
+      width: String(imageSize),
+      type: selectedExtention,
+      qrcolor: qrcolor.replace('#', ''),
+      bgcolor: bgcolor.replace('#', '')
+    })}`
   );
 </script>
 
@@ -69,11 +75,26 @@
     <div class="flex gap-5">
       <div class="w-1/2">
         <label for="qrcolor" class={labelClass}>QRコード色</label>
-        <input id="qrcolor" type="color" bind:value={qrcolor} class="{fieldClass} h-10" />
+        <!-- defaultValue を付けると Svelte がハイドレーション時の
+             remove_input_defaults を省くため、色入力で value 属性が一瞬
+             空になり出るコンソール警告を防げる -->
+        <input
+          id="qrcolor"
+          type="color"
+          bind:value={qrcolor}
+          defaultValue={DEFAULT_QR_COLOR}
+          class="{fieldClass} h-10"
+        />
       </div>
       <div class="w-1/2">
         <label for="bgcolor" class={labelClass}>QRコード背景色</label>
-        <input id="bgcolor" type="color" bind:value={bgcolor} class="{fieldClass} h-10" />
+        <input
+          id="bgcolor"
+          type="color"
+          bind:value={bgcolor}
+          defaultValue={DEFAULT_BG_COLOR}
+          class="{fieldClass} h-10"
+        />
       </div>
     </div>
   </form>


### PR DESCRIPTION
#169 のレビュー時に「既知の事項」として挙げていた2件と、あわせて README の記述漏れを対応する。

## 1. QR API に渡すクエリがエスケープされていない（バグ修正）

クエリを素の文字列連結で組み立てていたため、入力 URL に `&` や `?` が含まれるとクエリの区切りとして解釈され、URL が途中で切れていた。#169 以前からある既存バグ。

実機で再現を確認した。

| | API が受け取る `url` |
|---|---|
| 入力 | `https://example.com/search?q=svelte&lang=ja` |
| **修正前** | `https://example.com/search?q=svelte` ← 切れる |
| **修正後** | `https://example.com/search?q=svelte&lang=ja` |

修正前は切り落とされた `lang=ja` が独立したパラメータとして紛れ込み、パラメータ数が 5 → 6 になっていた。

`URLSearchParams` に組み立てを任せる形にした。ユーザー入力が入るのは `url` だけだが、個別に `encodeURIComponent` を挟むより組み立て全体を任せた方が読みやすく、取りこぼしも起きない。

```ts
const qrImageUrl = $derived(
  `https://qr.whyk.dev/api?${new URLSearchParams({
    url: url || 'https://example.com',
    width: String(imageSize),
    type: selectedExtention,
    qrcolor: qrcolor.replace('#', ''),
    bgcolor: bgcolor.replace('#', '')
  })}`
);
```

API 側がパーセントエンコード済みの URL を受け付けることは、`qr.whyk.dev` に直接リクエストして確認済み（200×200 の画像が返る）。修正後のアプリからも 450px の PNG が実際に生成されることを確認した。

## 2. `<input type="color">` のコンソール警告を解消

#169 では「Svelte の内部挙動でアプリ側からは回避できない」と書いたが、**回避策があったので訂正する**。

原因は Svelte がハイドレーション時に `remove_input_defaults` で `value` 属性を一旦削除することで、color 入力ではこの瞬間に値が `""` になり、ブラウザが `does not conform to #rrggbb` を警告していた。

Svelte のコンパイラは `defaultValue` 属性がある場合、`remove_input_defaults` の呼び出し自体を出力しない。

```js
// svelte/src/compiler/phases/3-transform/client/visitors/RegularElement.js:173-191
const has_default_value_attribute = attributes.some(
  (attribute) =>
    attribute.type === 'Attribute' &&
    (attribute.name === 'defaultValue' || attribute.name === 'defaultChecked')
);
if (
  !has_default_value_attribute &&
  (has_spread || bindings.has('value') || ...)
) {
  // remove_input_defaults を仕込む
}
```

よって `defaultValue` を付けるだけで根本的に消える。初期値は `DEFAULT_QR_COLOR` / `DEFAULT_BG_COLOR` に切り出し、`$state` の初期値と `defaultValue` が食い違わないようにした。`defaultValue` はフォームリセット時に戻る値でもあるので、意味的にも正しい形になっている。

## 3. README の記述を実態に合わせる

#169 で flowbite-svelte を依存から外したのに README に記述が残っていたため、Tailwind CSS に書き換える。あわせて SvelteKit のリンクを、リダイレクト元の `kit.svelte.dev` から現行の `svelte.dev/docs/kit` に更新した。

## 検証

- `pnpm check` … **0 errors / 0 warnings**
- `pnpm lint` … 通過
- `pnpm build` … 通過
- preview ビルドを Playwright で実機確認
  - **コンソール出力ゼロ**（修正前は警告2件）
  - `&` と `?` を含む URL が1つのパラメータとして正しく渡り、QR 画像が生成される
  - スライダー連動、png/svg 切替、カラーピッカー、ダークモード（localStorage 永続化）— 動作継続を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
