### PR TITLE
feat: Cloudflare Pages から Workers へ移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@
 
 [SvelteKit](https://svelte.dev/docs/kit)と[Tailwind CSS](https://tailwindcss.com)で実装。  
 QRコード生成APIは[QR server](https://github.com/windchime-yk/qr-server)を利用している。
+
+## デプロイ
+Cloudflare Workers（Static Assets）にデプロイしている。  
+設定は `wrangler.jsonc` にあり、`main` と `assets` があることで
+`@sveltejs/adapter-cloudflare` が Pages 向けではなく Workers 向けの出力を生成する。
+
+`main` ブランチへの push で Workers Builds が自動デプロイする。

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite build && wrangler dev",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "biome check .",
@@ -20,7 +20,8 @@
     "svelte-check": "^4.7.4",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3",
-    "vite": "^8.2.0"
+    "vite": "^8.2.0",
+    "wrangler": "^4.118.0"
   },
   "type": "module",
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.5.6
       '@sveltejs/adapter-cloudflare':
         specifier: ^7.2.9
-        version: 7.2.9(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(svelte@5.56.8)(typescript@6.0.3)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(wrangler@4.116.0)
+        version: 7.2.9(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(svelte@5.56.8)(typescript@6.0.3)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(wrangler@4.118.0)
       '@sveltejs/kit':
         specifier: ^2.70.2
         version: 2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(svelte@5.56.8)(typescript@6.0.3)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0))
@@ -35,6 +35,9 @@ importers:
       vite:
         specifier: ^8.2.0
         version: 8.2.0(esbuild@0.28.1)(jiti@2.7.0)
+      wrangler:
+        specifier: ^4.118.0
+        version: 4.118.0
 
 packages:
 
@@ -1023,10 +1026,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  miniflare@4.20260730.0:
-    resolution: {integrity: sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg==}
+  miniflare@5.20260730.0-alpha:
+    resolution: {integrity: sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==}
     engines: {node: '>=22.0.0'}
-    hasBin: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1205,8 +1207,8 @@ packages:
     resolution: {integrity: sha512-+TvsA6VAVoMC3XDKR5MoC/qlLqDixEfOBysDEKnPIPou/NvoPWCAuXHXMsswwlvmEuvX56lQjvELLyLuzTKvRw==}
     engines: {node: '>=12'}
 
-  wrangler@4.116.0:
-    resolution: {integrity: sha512-wP1PXxH5KJajfGEjty0NNqyxAirTFvMZpGyB5CRqEIiY0fL/SiCKtIYAJB9HXq0MP0sMXB/i/YSls+WObahAhw==}
+  wrangler@4.118.0:
+    resolution: {integrity: sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -1619,12 +1621,12 @@ snapshots:
     dependencies:
       acorn: 8.18.0
 
-  '@sveltejs/adapter-cloudflare@7.2.9(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(svelte@5.56.8)(typescript@6.0.3)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(wrangler@4.116.0)':
+  '@sveltejs/adapter-cloudflare@7.2.9(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(svelte@5.56.8)(typescript@6.0.3)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(wrangler@4.118.0)':
     dependencies:
       '@cloudflare/workers-types': 4.20260702.1
       '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(svelte@5.56.8)(typescript@6.0.3)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0))
       worktop: 0.8.0-next.18
-      wrangler: 4.116.0
+      wrangler: 4.118.0
 
   '@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0)))(svelte@5.56.8)(typescript@6.0.3)(vite@8.2.0(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
@@ -1929,7 +1931,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  miniflare@4.20260730.0:
+  miniflare@5.20260730.0-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
@@ -2123,13 +2125,13 @@ snapshots:
       mrmime: 2.0.0
       regexparam: 3.0.0
 
-  wrangler@4.116.0:
+  wrangler@4.118.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 4.20260730.0
+      miniflare: 5.20260730.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260730.1

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "qr-code-generater",
+  // adapter-cloudflare は wrangler 設定に main と assets があると
+  // Pages 向け出力ではなく Workers Static Assets 向け出力に切り替わる
+  "main": ".svelte-kit/cloudflare/_worker.js",
+  "compatibility_date": "2026-08-02",
+  "compatibility_flags": ["nodejs_als"],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": ".svelte-kit/cloudflare"
+  },
+  "observability": {
+    "enabled": true
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,8 +9,5 @@
   "assets": {
     "binding": "ASSETS",
     "directory": ".svelte-kit/cloudflare"
-  },
-  "observability": {
-    "enabled": true
   }
 }


### PR DESCRIPTION
## 概要
デプロイ先を Cloudflare Pages から Cloudflare Workers（Static Assets）へ移行する。

`@sveltejs/adapter-cloudflare` は wrangler 設定に `main` と `assets` があると
Pages 向けではなく Workers 向けの出力を生成するため、`wrangler.jsonc` を追加した。

## 変更内容
| ファイル | 内容 |
|---|---|
| `wrangler.jsonc` | 新規。`main` + `assets`(binding `ASSETS`)、`compatibility_flags: ["nodejs_als"]` |
| `package.json` | `wrangler` を devDependency に追加、`preview` を `vite build && wrangler dev` に変更 |
| `README.md` | デプロイ節を追記 |

デプロイは Workers Builds の Git 連携で行うため、リポジトリ側に CI 設定は置いていない。

## ビルド出力の変化
Pages モードの `_routes.json` と `404.html` が消え、代わりに `_worker.js` を
静的配信から除外する `.assetsignore` が生成されるようになった。
`_headers` の immutable キャッシュ設定は Workers Assets でもそのまま有効。

## 検証
- `pnpm run build` → Workers モード出力に切り替わることを確認
- `wrangler deploy --dry-run` → 成功（22 ファイル / 358.84 KiB、`env.ASSETS` 認識）
- `pnpm run preview`（`wrangler dev`）→ ローカルで正常に配信されることを確認
- `pnpm lint` → エラーなし
- `pnpm check` → 216 ファイル、0 エラー

このアプリはサーバー処理もバインディング利用も無いため、ランタイム挙動は移行前後で変わらない。
`wrangler types` による `App.Platform` の型付けは、生成物がビルド成果物を `checkJs` の
対象に引き込んで `pnpm check` を壊すため見送った。

## マージ後に必要なダッシュボード作業
1. Workers & Pages → Create → Import a repository でこのリポジトリを接続
2. ビルドコマンド `pnpm run build` / デプロイコマンド `npx wrangler deploy`
3. Pages 側のカスタムドメインを Worker の Custom Domains へ付け替え
4. 動作確認後に Pages プロジェクトを削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)